### PR TITLE
Fixed Highest resolution for different camera devices

### DIFF
--- a/Moodis/Moodis/Feature/Camera/cameraForm.cs
+++ b/Moodis/Moodis/Feature/Camera/cameraForm.cs
@@ -37,15 +37,8 @@ namespace moodis
             }
             cmbOutputDevices.SelectedIndex = 0;
 
+            setHighestResoliution(cam);
             cam = new VideoCaptureDevice(webcam[cmbOutputDevices.SelectedIndex].MonikerString);
-
-            foreach (var option in cam.VideoCapabilities)
-            {
-                string temp = option.FrameSize.Width.ToString() + " * " + option.FrameSize.Height.ToString();
-                cmbCamResoliution.Items.Add(temp);
-            }
-
-            cmbCamResoliution.SelectedIndex = cmbCamResoliution.Items.Count-1;
             cam.NewFrame += new NewFrameEventHandler(cam_newFrame);
             cam.Start();
         }
@@ -124,9 +117,23 @@ namespace moodis
             }
         }
 
-        private void int indexOfHighestResoliution(var cam)
+        private void setHighestResoliution(VideoCaptureDevice cam)
         {
-            return 0;
+            int index = -1;
+            int highestResoliution = 0;
+            foreach (var option in cam.VideoCapabilities)
+            {
+                int height = option.FrameSize.Height;
+                int width = option.FrameSize.Width;
+                string temp = width.ToString() + "*" + height.ToString();
+                cmbCamResoliution.Items.Add(temp);
+                if (height * width < highestResoliution)
+                {
+                    highestResoliution = height * width;
+                    index = cmbCamResoliution.Items.Count;
+                }              
+            }
+            cmbCamResoliution.SelectedIndex = index;
         }
     }
 }

--- a/Moodis/Moodis/Feature/Camera/cameraForm.cs
+++ b/Moodis/Moodis/Feature/Camera/cameraForm.cs
@@ -123,5 +123,10 @@ namespace moodis
                 Console.WriteLine(ex.ToString());
             }
         }
+
+        private void int indexOfHighestResoliution(var cam)
+        {
+            return 0;
+        }
     }
 }

--- a/Moodis/Moodis/Feature/Camera/cameraForm.cs
+++ b/Moodis/Moodis/Feature/Camera/cameraForm.cs
@@ -37,8 +37,8 @@ namespace moodis
             }
             cmbOutputDevices.SelectedIndex = 0;
 
-            setHighestResoliution(cam);
             cam = new VideoCaptureDevice(webcam[cmbOutputDevices.SelectedIndex].MonikerString);
+            setHighestResoliution(cam);
             cam.NewFrame += new NewFrameEventHandler(cam_newFrame);
             cam.Start();
         }
@@ -127,10 +127,11 @@ namespace moodis
                 int width = option.FrameSize.Width;
                 string temp = width.ToString() + "*" + height.ToString();
                 cmbCamResoliution.Items.Add(temp);
-                if (height * width < highestResoliution)
+                if (height * width > highestResoliution)
                 {
                     highestResoliution = height * width;
-                    index = cmbCamResoliution.Items.Count;
+                    index = cmbCamResoliution.Items.Count-1;
+                    Console.WriteLine(index);
                 }              
             }
             cmbCamResoliution.SelectedIndex = index;


### PR DESCRIPTION
Now, no matter the camera default resolution values and order a simple pixel evaluation will check for the highest pixel count and set it as the default resolution to to run the camera